### PR TITLE
Add CSS style sheet with @font-face declaration

### DIFF
--- a/webfonts/Sniglet.css
+++ b/webfonts/Sniglet.css
@@ -1,0 +1,16 @@
+/*
+  'Sniglet'
+  https://www.theleagueofmoveabletype.com/sniglet
+
+  Copyright (c) 2008, Haley Fiege <haley@kingdomofawesome.com>, with Reserved Font Name: "Sniglet".
+
+  This Font Software is licensed under the SIL Open Font License, Version 1.1.
+  http://scripts.sil.org/OFL
+*/
+@font-face {
+  font-family: 'Sniglet';
+  src: url('Sniglet-webfont.eot?#iefix') format('embedded-opentype'),
+       url('Sniglet-webfont.woff') format('woff'),
+       url('Sniglet-webfont.ttf')  format('truetype'),
+       url('Sniglet-webfont.svg#webfontGFFODQKC') format('svg');
+}

--- a/webfonts/Sniglet.css
+++ b/webfonts/Sniglet.css
@@ -9,6 +9,7 @@
 */
 @font-face {
   font-family: 'Sniglet';
+  src: url('Sniglet-webfont.eot'),
   src: url('Sniglet-webfont.eot?#iefix') format('embedded-opentype'),
        url('Sniglet-webfont.woff') format('woff'),
        url('Sniglet-webfont.ttf')  format('truetype'),

--- a/webfonts/Sniglet.css
+++ b/webfonts/Sniglet.css
@@ -9,7 +9,7 @@
 */
 @font-face {
   font-family: 'Sniglet';
-  src: url('Sniglet-webfont.eot'),
+  src: url('Sniglet-webfont.eot');
   src: url('Sniglet-webfont.eot?#iefix') format('embedded-opentype'),
        url('Sniglet-webfont.woff') format('woff'),
        url('Sniglet-webfont.ttf')  format('truetype'),


### PR DESCRIPTION
The format used for the @font-face declaration is the
"Fontspring @Font-Face Syntax"[1] considered [2]
"the most simple and compatible one".

[1] The New Bulletproof @Font-Face Syntax
2011-02-03 (last updated: 2011-04-21)
http://www.fontspring.com/blog/the-new-bulletproof-font-face-syntax

[2] The @Font-Face Rule And Useful Web Font Tricks
2011-03-02, by Ralf Hermann
http://www.smashingmagazine.com/2011/03/02/the-font-face-rule-revisited-and-useful-tricks/
